### PR TITLE
Lower min cmake3 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.20)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
 project(minecraft)


### PR DESCRIPTION
- cmake3 v23 is quite new, and not a lot of systems (IE: Ubuntu 22.04) have it available.
- cmake3 v20 is a reasonable compromise IMO

Tested as working on Ubuntu 22.04.3 LTS with cmake3.22.1