### PR TITLE
Only draw/delay after handling all pending events, not just one.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
 				default:
 					break;
 			}
-        }
+		}
 
 		glClearColor((0xab)/255.0, 0x10/255.0, 0xfe/255.0, 1.0);
 		glClear(GL_COLOR_BUFFER_BIT);

--- a/src/main.c
+++ b/src/main.c
@@ -152,16 +152,16 @@ int main(int argc, char *argv[])
 				default:
 					break;
 			}
+        }
 
-			glClearColor((0xab)/255.0, 0x10/255.0, 0xfe/255.0, 1.0);
-			glClear(GL_COLOR_BUFFER_BIT);
-			glUseProgram(shaderProgram);
-			glBindBuffer(GL_ARRAY_BUFFER,vertex_buffer);
-			glDrawArrays(GL_TRIANGLES,0,3);
+		glClearColor((0xab)/255.0, 0x10/255.0, 0xfe/255.0, 1.0);
+		glClear(GL_COLOR_BUFFER_BIT);
+		glUseProgram(shaderProgram);
+		glBindBuffer(GL_ARRAY_BUFFER,vertex_buffer);
+		glDrawArrays(GL_TRIANGLES,0,3);
 
-			SDL_GL_SwapWindow(w);
-			SDL_Delay(1000/60);
-		}
+		SDL_GL_SwapWindow(w);
+		SDL_Delay(1000/60);
 	}
 
 	SDL_DestroyWindow(w);


### PR DESCRIPTION
Currently, moving the mouse around and then clicking makes the program take a while to respond, because it is waiting 16 milliseconds between handling *every* event, including mouse movement events. This PR moves the delay (and the rendering) out of the event-handling loop, so rendering and the frame delay will only occur after all pending events have been handled.

Possible future work:

* Account for the time taken to handle events when calculating delay, instead of hard-coding 16ms. (Probably won't be an issue for a while).